### PR TITLE
Fixes an issue where a restore after a reset would not work

### DIFF
--- a/Plugin/version.h
+++ b/Plugin/version.h
@@ -2,7 +2,7 @@
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 2
 #define VERSION_PATCH 2
-#define VERSION_BUILD 644
+#define VERSION_BUILD 645
 
 #define stringify(a) stringify_(a)
 #define stringify_(a) #a


### PR DESCRIPTION
Fixes bug #43: Restoring a session directly after a reset will now work as expected. This indirectly fixes issues with stat comparison and toggling the previous shot