### PR TITLE
Fixes coloring of negative values in some regions

### DIFF
--- a/Plugin/Display/StatDisplay.cpp
+++ b/Plugin/Display/StatDisplay.cpp
@@ -78,7 +78,14 @@ void drawStat(CanvasWrapper& canvas, const DisplayOptions& displayOpts, int rowN
 		LinearColor diffColor;
 		diffColor.B = .0;
 		diffColor.A = 255.0;
-		if (std::stod(statStrings.DiffValue.value()) >= .0)
+
+		// Switch to OS locale temporarily in order to convert the value string back to double
+		const std::string oldLocale = std::setlocale(LC_NUMERIC, nullptr);
+		std::setlocale(LC_NUMERIC, "");
+		double diffValue = std::stod(statStrings.DiffValue.value());
+		std::setlocale(LC_NUMERIC, oldLocale.c_str());
+
+		if (diffValue >= .0)
 		{
 			diffColor.R = .0;
 			diffColor.G = 255.0;

--- a/Plugin/Storage/StatFileReader.cpp
+++ b/Plugin/Storage/StatFileReader.cpp
@@ -373,4 +373,6 @@ bool StatFileReader::readVersion_1_3_additions(std::ifstream& fileStream, StatsD
 			offset = separatorPos + 1;
 		}
 	}
+
+	return true;
 }

--- a/Plugin/version.h
+++ b/Plugin/version.h
@@ -2,7 +2,7 @@
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 3
 #define VERSION_PATCH 1
-#define VERSION_BUILD 1048
+#define VERSION_BUILD 1052
 
 #define stringify(a) stringify_(a)
 #define stringify_(a) #a


### PR DESCRIPTION
Regions which use the comma as a decimal separator would fail to properly check whether or not a value between -1.0 (exclusively) and .0 would be negative
(Fixes issue #74 )